### PR TITLE
feat: support album art for image

### DIFF
--- a/art.go
+++ b/art.go
@@ -1,0 +1,101 @@
+package main
+
+// credit to https://github.com/lacymorrow/album-art
+// thanks for the token too :)
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	// "sort"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	art_endpoint = "https://api.spotify.com/v1"
+	auth_endpoint = "https://accounts.spotify.com/api/token"
+	art_api_id = "3f974573800a4ff5b325de9795b8e603"
+	art_api_secret = "ff188d2860ff44baa57acc79c121a3b9"
+	art_api_auth = art_api_id + ":" + art_api_secret
+)
+
+type spotifyAccess struct{
+	AccessToken string `json:"access_token"`
+}
+
+type spotifySeach struct{
+	Albums spotifyAlbums
+}
+
+type spotifyAlbums struct{
+	Items []spotifyItem
+}
+
+type spotifyItem struct{
+	Images []spotifyArt
+}
+
+type spotifyArt struct {
+	Width int
+	Height int
+	URL string
+}
+
+func getAlbumArt(artist, album string, mdata map[string]dbus.Variant) string {
+	println("here")
+	artUrl, _ := url.Parse(fmt.Sprintf("%s/search?q=%s&type=album&limit=1", art_endpoint, url.QueryEscape(artist + " " + album)))
+	fmt.Println(artUrl)
+	authUrl, _ := url.Parse(auth_endpoint)
+
+	fmt.Println(authUrl.String())
+	req, err := http.NewRequest("POST", authUrl.String(), strings.NewReader("grant_type=client_credentials"))
+	if err != nil {
+		// TODO: dont panic
+		panic(err)
+	}
+	req.Header.Add("Authorization", "Basic " + base64.StdEncoding.EncodeToString([]byte(art_api_auth)))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	spot := &spotifyAccess{}
+	if err := json.Unmarshal(body, &spot); err != nil {
+		panic(err)
+	}
+
+	req, err = http.NewRequest("GET", artUrl.String(), strings.NewReader(""))
+	req.Header.Add("Authorization", "Bearer " + spot.AccessToken)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
+	body, err = io.ReadAll(resp.Body)
+	fmt.Println(string(body))
+
+	spotifyData := &spotifySeach{}
+	if err := json.Unmarshal(body, &spotifyData); err != nil {
+		panic(err)
+	}
+
+	images := spotifyData.Albums.Items[0].Images
+	// may or may not be needed (will see)
+	/*
+	sort.Slice(images, func(i, j int) bool {
+		return images[i].Width > images[j].Width
+	})
+	*/
+
+	return images[0].URL
+}

--- a/art.go
+++ b/art.go
@@ -47,12 +47,9 @@ type spotifyArt struct {
 }
 
 func getAlbumArt(artist, album string, mdata map[string]dbus.Variant) string {
-	println("here")
 	artUrl, _ := url.Parse(fmt.Sprintf("%s/search?q=%s&type=album&limit=1", art_endpoint, url.QueryEscape(artist + " " + album)))
-	fmt.Println(artUrl)
 	authUrl, _ := url.Parse(auth_endpoint)
 
-	fmt.Println(authUrl.String())
 	req, err := http.NewRequest("POST", authUrl.String(), strings.NewReader("grant_type=client_credentials"))
 	if err != nil {
 		// TODO: dont panic
@@ -82,7 +79,7 @@ func getAlbumArt(artist, album string, mdata map[string]dbus.Variant) string {
 	}
 
 	body, err = io.ReadAll(resp.Body)
-	fmt.Println(string(body))
+	logger.Debug(string(body))
 
 	spotifyData := &spotifySeach{}
 	if err := json.Unmarshal(body, &spotifyData); err != nil {

--- a/artfetcher.go
+++ b/artfetcher.go
@@ -3,5 +3,5 @@ package main
 import "github.com/godbus/dbus/v5"
 
 type artFetcher interface{
-	getAlbumArt(artist, album string, metadata map[string]dbus.Variant) string
+	getAlbumArt(artist, album, title string, metadata map[string]dbus.Variant) string
 }

--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,13 @@
+package main
+
+type Asset struct {
+	ID string `json:"id"`
+	Name string `json:"name"`
+}
+
+type AssetToUpload struct {
+	Name string `json:"name"`
+	Type string `json:"type"` // always 1
+	Image string `json:"image"` // base64 encoded
+}
+

--- a/discord.go
+++ b/discord.go
@@ -22,7 +22,7 @@ var receivedAssets []Asset
 
 type discordFetcher struct{}
 
-func (discordFetcher) getAlbumArt(artist, album string, mdata map[string]dbus.Variant) string {
+func (discordFetcher) getAlbumArt(artist, album, title string, mdata map[string]dbus.Variant) string {
 	artFile := ""
 	if artUrl, ok := mdata["mpris:artUrl"].Value().(string); ok {
 		artFile, _ = url.PathUnescape(artUrl)

--- a/main.go
+++ b/main.go
@@ -224,6 +224,8 @@ func setPresence(metadata map[string]dbus.Variant, songstamp time.Time, player *
 		artistsStr = "by " + strings.Join(artistsArr, ", ")
 	}
 
+	url := getAlbumArt(strings.Join(metadata["xesam:artist"].Value().([]string), ", "), metadata["xesam:album"].Value().(string), metadata)
+
 	args := []string{
 		"{artist}", artistsStr,
 		"{title}", title,
@@ -243,7 +245,7 @@ func setPresence(metadata map[string]dbus.Variant, songstamp time.Time, player *
 	client.SetActivity(client.Activity{
 		Details: replacer.Replace(p.Details),
 		State: replacer.Replace(p.State),
-		LargeImage: "music",
+		LargeImage: url,
 		LargeText: playerIdentity,
 		SmallImage: strings.ToLower(string(pbStat)),
 		SmallText: string(pbStat),

--- a/main.go
+++ b/main.go
@@ -232,13 +232,13 @@ func setPresence(metadata map[string]dbus.Variant, songstamp time.Time, player *
 
 	artistsStr := ""
 	if artistsArr, ok := metadata["xesam:artist"].Value().([]string); ok {
-		artistsStr = "by " + strings.Join(artistsArr, ", ")
+		artistsStr = strings.Join(artistsArr, ", ")
 	}
 
-	url := fetcher.getAlbumArt(artistsStr, albumName, metadata)
+	url := fetcher.getAlbumArt(artistsStr, albumName, title, metadata)
 
 	args := []string{
-		"{artist}", artistsStr,
+		"{artist}", "by " + artistsStr,
 		"{title}", title,
 		"{album}", album,
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var tokenRegex = regexp.MustCompile(`mfa\.[\w-]{84}`)
+var receivedAssets []Asset
+
+// function to get token from local discord db
+func getDiscordToken() string {
+	discordDir := os.Getenv("HOME") + "/.config/discord"
+	dbDir := discordDir + "/Local Storage/leveldb/"
+	// get files in dbDir
+	files, err := os.ReadDir(dbDir)
+	dbs := []fs.DirEntry{}
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	// add file to dbs if it ends with .ldb
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".ldb") {
+			dbs = append(dbs, file)
+		}
+	}
+
+	// sort by modification time
+	sort.Slice(files, func(i, j int) bool {
+		firstFileInfo, _ := files[i].Info()
+		secondFileInfo, _ := files[j].Info()
+		return firstFileInfo.ModTime().After(secondFileInfo.ModTime())
+	})
+
+	// go through all leveldbs to find the one with the token
+	for _, dbFile := range dbs {
+		dbContents, err := os.ReadFile(dbDir + dbFile.Name())
+		if err != nil {
+			fmt.Println(err)
+			return ""
+		}
+
+		// return single regex match
+		token := tokenRegex.FindString(string(dbContents))
+		if token != "" {
+			return token
+		}
+	}
+
+	return ""
+}
+
+func getAssets() []Asset {
+	// make get request to get assets
+	if len(receivedAssets) != 0 {
+		return receivedAssets
+	}
+	resp, err := http.Get("https://discord.com/api/v9/oauth2/applications/902662551119224852/assets")
+	if err != nil {
+		fmt.Println(err)
+		return []Asset{}
+	}
+
+	var assets []Asset
+	json.NewDecoder(resp.Body).Decode(&assets)
+
+	receivedAssets = assets
+	return receivedAssets
+}
+
+// upload asset to discord
+// assetName will be the album name, or song name if no album
+// "music" is returned as the assetName when an error occurs since that's the name of just a music icon
+func uploadAsset(fileName, assetName string) (string, error) {
+	image, err := os.ReadFile(fileName)
+	if err != nil {
+		return "music", err
+	}
+
+	base64Encoding := ""
+
+	// determine the content type of the image file
+	imageType := http.DetectContentType(image)
+
+	// album art is only going to be jpg or png, right?
+	// if not i hate you
+	switch imageType {
+	case "image/jpeg":
+		base64Encoding += "data:image/jpeg;base64,"
+	case "image/png":
+		base64Encoding += "data:image/png;base64,"
+	}
+
+	base64Encoding += base64.StdEncoding.EncodeToString(image)
+
+	// turn assetName into a hex encoded string
+	assetNameEncoded := hex.EncodeToString([]byte(assetName))
+
+	asset := AssetToUpload{
+		Type: "1",
+		Name: assetNameEncoded,
+		Image: base64Encoding,
+	}
+
+	// make post request to upload asset, using token in Authentication header
+	jsonBytes, err := json.Marshal(asset)
+	req, _ := http.NewRequest("POST", "https://discord.com/api/v9/oauth2/applications/902662551119224852/assets", bytes.NewBuffer(jsonBytes))
+
+	req.Header.Set("Authorization", getDiscordToken())
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "music", err
+	}
+	var receivedAssetInfo Asset
+	json.NewDecoder(resp.Body).Decode(&receivedAssetInfo)
+	resp.Body.Close()
+	fmt.Println(receivedAssetInfo)
+
+	receivedAssets = append(receivedAssets, receivedAssetInfo)
+
+	return assetName, nil
+}
+
+func checkForAsset(albumName string) (string, error) {
+	// get assets from discord
+	assets := getAssets()
+	
+	albumNameEncoded := hex.EncodeToString([]byte(albumName))
+
+	// go through assets to see if one matches fileName
+	for _, asset := range assets {
+		if asset.Name == albumNameEncoded {
+			fmt.Println("found asset")
+			return asset.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("No asset found for %s", albumName)
+}


### PR DESCRIPTION
add the ability to set album art on the large image instead of the generic note icon based on these methods:
- [x] spotify api
- [x] uploading image to discord

closes #4 and would be merged with the previous branch (dynamic-album-art)

other tasks
- [x] config option
  - [x] use album art
  - [x] art fetching method
- [x] error handling